### PR TITLE
Fix pathnames handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ var debug = require('debug')('imageminFilter');
 var prettyBytes = require('pretty-bytes');
 var mode = require('stat-mode');
 var fs = require('fs');
-var Promise = require('rsvp').Promise
+var Promise = require('rsvp').Promise;
+var path = require('path');
 
 function imageminFilter(inputTree, optns) {
 	debug('Creating imageminFilter instance');
@@ -48,7 +49,7 @@ imageminFilter.prototype.constructor = imageminFilter;
 imageminFilter.prototype.extensions = ['png', 'jpg', 'jpeg', 'gif', 'svg'];
 
 imageminFilter.prototype.processString = function(str, srcDir, file) {
-  var fileNamePath = srcDir + '/' + file;
+  var fileNamePath = path.join(srcDir, file);
   debug('Processing Buffer ' + fileNamePath);
 
   var extenson = this.targetExtension = file.split('.').pop().toLowerCase();
@@ -87,11 +88,11 @@ imageminFilter.prototype.processString = function(str, srcDir, file) {
 
 imageminFilter.prototype.processFile = function (srcDir, destDir, relativePath) {
   var self = this
-  var string = fs.readFileSync(srcDir + '/' + relativePath);
+  var string = fs.readFileSync(path.join(srcDir, relativePath));
   return self.processString(string, srcDir, relativePath)
     .then(function (outputString) {
       var outputPath = self.getDestFilePath(relativePath)
-      fs.writeFileSync(destDir + '/' + outputPath, outputString)
+      fs.writeFileSync(path.join(destDir, outputPath), outputString)
     });
 };
 

--- a/index.js
+++ b/index.js
@@ -47,8 +47,8 @@ imageminFilter.prototype.constructor = imageminFilter;
 
 imageminFilter.prototype.extensions = ['png', 'jpg', 'jpeg', 'gif', 'svg'];
 
-imageminFilter.prototype.processString = function(str, file) {
-  var fileNamePath = './' + this.inputTree + '/' + file;
+imageminFilter.prototype.processString = function(str, srcDir, file) {
+  var fileNamePath = srcDir + '/' + file;
   debug('Processing Buffer ' + fileNamePath);
 
   var extenson = this.targetExtension = file.split('.').pop().toLowerCase();
@@ -88,7 +88,7 @@ imageminFilter.prototype.processString = function(str, file) {
 imageminFilter.prototype.processFile = function (srcDir, destDir, relativePath) {
   var self = this
   var string = fs.readFileSync(srcDir + '/' + relativePath);
-  return self.processString(string, relativePath)
+  return self.processString(string, srcDir, relativePath)
     .then(function (outputString) {
       var outputPath = self.getDestFilePath(relativePath)
       fs.writeFileSync(destDir + '/' + outputPath, outputString)


### PR DESCRIPTION
Tried to use the plugin today and stumbled upon the fact it used broccoli tree objects as a string. That I believe was okay in the old days, but now it leads to bailing out along the lines of:

```
[broccoli-debug] [TreeMerger tree] Error: ENOENT, no such file or directory './[object Object]/images/logo.svg'
File: images/logo.svg
Error: ENOENT, no such file or directory './[object Object]/images/logo.svg'
  at Object.fs.statSync (fs.js:695:18)
  at imageminFilter.processString (.../node_modules/broccoli-imagemin/index.js:57:17)
  at imageminFilter.processFile (.../node_modules/broccoli-imagemin/index.js:89:31)
...
```

The PR fixes this by propagating the srcDir variable from the processFile method into the processString call.
Plus, the file paths are now constructed with path.join(...) calls, which is safer than concatenating strings.

Hope this helps and you would merge it. Cheers. :)
